### PR TITLE
integrate build CLI with Bullseye

### DIFF
--- a/tools/build/build.csproj
+++ b/tools/build/build.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bullseye" Version="2.3.0" />
+    <PackageReference Include="Bullseye" Version="3.2.0-alpha.1" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
     <PackageReference Include="SimpleExec" Version="5.0.1" />
     <PackageReference Include="vswhere" Version="2.8.4" />


### PR DESCRIPTION
By integrating Bullseye with McMaster (using new API's from Bullseye 3.2.0), you get proper help from you build script, including your custom option (`-c|--configuration`) and all the Bullseye options:

![image](https://user-images.githubusercontent.com/677704/71364585-91386080-2594-11ea-80d5-f87c7952d5d8.png)
