### PR TITLE
Fix Min/Max(By) to correctly handle null values

### DIFF
--- a/src/Linq.Extras/Internal/MaybeNullAttribute.cs
+++ b/src/Linq.Extras/Internal/MaybeNullAttribute.cs
@@ -1,0 +1,8 @@
+﻿namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed class MaybeNullAttribute : Attribute
+    {
+    }
+}

--- a/src/Linq.Extras/MinMax.cs
+++ b/src/Linq.Extras/MinMax.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
 using Linq.Extras.Internal;
 using Linq.Extras.Properties;
@@ -22,6 +23,7 @@ namespace Linq.Extras
         /// If <c>TSource</c> is a value type, and the sequence is empty, the method will throw an <see cref="InvalidOperationException"/>.
         /// </remarks>
         [Pure]
+        [return: MaybeNull]
         public static TSource Max<TSource>(
             [NotNull] this IEnumerable<TSource> source,
             [NotNull] IComparer<TSource> comparer)
@@ -45,6 +47,7 @@ namespace Linq.Extras
         /// If <c>TSource</c> is a value type, and the sequence is empty, the method will throw an <see cref="InvalidOperationException"/>.
         /// </remarks>
         [Pure]
+        [return: MaybeNull]
         public static TSource Min<TSource>(
             [NotNull] this IEnumerable<TSource> source,
             [NotNull] IComparer<TSource> comparer)
@@ -134,6 +137,7 @@ namespace Linq.Extras
         /// If <c>TKey</c> is a value type, and the sequence is empty, the method will throw an <see cref="InvalidOperationException"/>.
         /// </remarks>
         [Pure]
+        [return: MaybeNull]
         public static TSource MaxBy<TSource, TKey>(
             [NotNull] this IEnumerable<TSource> source,
             [NotNull] Func<TSource, TKey> keySelector,
@@ -160,6 +164,7 @@ namespace Linq.Extras
         /// If <c>TKey</c> is a value type, and the sequence is empty, the method will throw an <see cref="InvalidOperationException"/>.
         /// </remarks>
         [Pure]
+        [return: MaybeNull]
         public static TSource MinBy<TSource, TKey>(
             [NotNull] this IEnumerable<TSource> source,
             [NotNull] Func<TSource, TKey> keySelector,

--- a/src/Linq.Extras/MinMax.cs
+++ b/src/Linq.Extras/MinMax.cs
@@ -15,6 +15,12 @@ namespace Linq.Extras
         /// <param name="source">The sequence to return the maximum element from.</param>
         /// <param name="comparer">The comparer used to compare elements.</param>
         /// <returns>The maximum element according to the specified comparer.</returns>
+        /// <remarks>
+        /// If <c>TSource</c> is a reference type or nullable value type, null values are ignored, unless the sequence consists
+        /// entirely of null values (in which case the method will return null).
+        /// If <c>TSource</c> is a reference type or nullable value type, and the sequence is empty, the method will return <c>null</c>.
+        /// If <c>TSource</c> is a value type, and the sequence is empty, the method will throw an <see cref="InvalidOperationException"/>.
+        /// </remarks>
         [Pure]
         public static TSource Max<TSource>(
             [NotNull] this IEnumerable<TSource> source,
@@ -32,6 +38,12 @@ namespace Linq.Extras
         /// <param name="source">The sequence to return the minimum element from.</param>
         /// <param name="comparer">The comparer used to compare elements.</param>
         /// <returns>The minimum element according to the specified comparer.</returns>
+        /// <remarks>
+        /// If <c>TSource</c> is a reference type or nullable value type, null values are ignored, unless the sequence consists
+        /// entirely of null values (in which case the method will return null).
+        /// If <c>TSource</c> is a reference type or nullable value type, and the sequence is empty, the method will return <c>null</c>.
+        /// If <c>TSource</c> is a value type, and the sequence is empty, the method will throw an <see cref="InvalidOperationException"/>.
+        /// </remarks>
         [Pure]
         public static TSource Min<TSource>(
             [NotNull] this IEnumerable<TSource> source,
@@ -47,22 +59,56 @@ namespace Linq.Extras
         {
             comparer = comparer ?? Comparer<TSource>.Default;
             TSource extreme = default!;
-            bool first = true;
-            foreach (var item in source)
+
+            using var e = source.GetEnumerator();
+            if (extreme is null)
             {
-                int compare = 0;
-                if (!first)
-                    compare = comparer.Compare(item, extreme);
+                // For nullable types, return null if the sequence is empty
+                // or contains only null values.
 
-                if (Math.Sign(compare) == sign || first)
+                // First, skip until the first non-null value, if any
+                do
                 {
-                    extreme = item;
-                }
-                first = false;
-            }
+                    if (!e.MoveNext())
+                    {
+                        return extreme;
+                    }
 
-            if (first)
-                throw EmptySequenceException();
+                    extreme = e.Current;
+                } while (extreme is null);
+
+                while (e.MoveNext())
+                {
+                    if (e.Current is null)
+                    {
+                        continue;
+                    }
+
+                    if (Math.Sign(comparer.Compare(e.Current, extreme)) == sign)
+                    {
+                        extreme = e.Current;
+                    }
+                }
+            }
+            else
+            {
+                // For non-nullable types, throw an exception if the sequence is empty
+
+                if (!e.MoveNext())
+                {
+                    throw EmptySequenceException();
+                }
+
+                extreme = e.Current;
+
+                while (e.MoveNext())
+                {
+                    if (Math.Sign(comparer.Compare(e.Current, extreme)) == sign)
+                    {
+                        extreme = e.Current;
+                    }
+                }
+            }
 
             return extreme;
         }
@@ -81,6 +127,12 @@ namespace Linq.Extras
         /// <param name="keySelector">A delegate that returns the key used to compare elements.</param>
         /// <param name="keyComparer">A comparer to compare the keys.</param>
         /// <returns>The element of <c>source</c> that has the maximum value for the specified key.</returns>
+        /// <remarks>
+        /// If <c>TKey</c> is a reference type or nullable value type, null keys are ignored, unless the sequence consists
+        /// entirely of items with null keys (in which case the method will return null).
+        /// If <c>TKey</c> is a reference type or nullable value type, and the sequence is empty, the method will return <c>null</c>.
+        /// If <c>TKey</c> is a value type, and the sequence is empty, the method will throw an <see cref="InvalidOperationException"/>.
+        /// </remarks>
         [Pure]
         public static TSource MaxBy<TSource, TKey>(
             [NotNull] this IEnumerable<TSource> source,
@@ -89,8 +141,7 @@ namespace Linq.Extras
         {
             source.CheckArgumentNull(nameof(source));
             keySelector.CheckArgumentNull(nameof(keySelector));
-            var comparer = XComparer.By(keySelector, keyComparer);
-            return source.Max(comparer);
+            return source.ExtremeBy(keySelector, keyComparer, 1);
         }
 
         /// <summary>
@@ -102,6 +153,12 @@ namespace Linq.Extras
         /// <param name="keySelector">A delegate that returns the key used to compare elements.</param>
         /// <param name="keyComparer">A comparer to compare the keys.</param>
         /// <returns>The element of <c>source</c> that has the minimum value for the specified key.</returns>
+        /// <remarks>
+        /// If <c>TKey</c> is a reference type or nullable value type, null keys are ignored, unless the sequence consists
+        /// entirely of items with null keys (in which case the method will return null).
+        /// If <c>TKey</c> is a reference type or nullable value type, and the sequence is empty, the method will return <c>null</c>.
+        /// If <c>TKey</c> is a value type, and the sequence is empty, the method will throw an <see cref="InvalidOperationException"/>.
+        /// </remarks>
         [Pure]
         public static TSource MinBy<TSource, TKey>(
             [NotNull] this IEnumerable<TSource> source,
@@ -110,8 +167,78 @@ namespace Linq.Extras
         {
             source.CheckArgumentNull(nameof(source));
             keySelector.CheckArgumentNull(nameof(keySelector));
-            var comparer = XComparer.By(keySelector, keyComparer);
-            return source.Min(comparer);
+            return source.ExtremeBy(keySelector, keyComparer, -1);
+        }
+
+        [Pure]
+        private static TSource ExtremeBy<TSource, TKey>(
+            this IEnumerable<TSource> source,
+            Func<TSource, TKey> keySelector,
+            IComparer<TKey>? keyComparer,
+            int sign)
+        {
+            keyComparer = keyComparer ?? Comparer<TKey>.Default;
+            TSource extreme = default!;
+            TKey extremeKey = default!;
+
+            using var e = source.GetEnumerator();
+
+            if (extremeKey is null)
+            {
+                // For nullable types, return null if the sequence is empty
+                // or contains only values with null keys.
+
+                // First, skip until the first non-null key value, if any
+                do
+                {
+                    if (!e.MoveNext())
+                    {
+                        return extreme;
+                    }
+
+                    extreme = e.Current;
+                    extremeKey = keySelector(extreme);
+                } while (extremeKey is null);
+
+                while (e.MoveNext())
+                {
+                    var currentKey = keySelector(e.Current);
+                    if (currentKey is null)
+                    {
+                        continue;
+                    }
+
+                    if (Math.Sign(keyComparer.Compare(currentKey, extremeKey)) == sign)
+                    {
+                        extreme = e.Current;
+                        extremeKey = currentKey;
+                    }
+                }
+            }
+            else
+            {
+                // For non-nullable types, throw an exception if the sequence is empty
+
+                if (!e.MoveNext())
+                {
+                    throw EmptySequenceException();
+                }
+
+                extreme = e.Current;
+                extremeKey = keySelector(e.Current);
+
+                while (e.MoveNext())
+                {
+                    var currentKey = keySelector(e.Current);
+                    if (Math.Sign(keyComparer.Compare(currentKey, extremeKey)) == sign)
+                    {
+                        extreme = e.Current;
+                        extremeKey = currentKey;
+                    }
+                }
+            }
+
+            return extreme;
         }
     }
 }

--- a/tests/Linq.Extras.Tests/XEnumerableTests/MinMaxTests.cs
+++ b/tests/Linq.Extras.Tests/XEnumerableTests/MinMaxTests.cs
@@ -18,11 +18,19 @@ namespace Linq.Extras.Tests.XEnumerableTests
         }
 
         [Fact]
-        public void MaxBy_Throws_If_Source_Is_Empty()
+        public void MaxBy_Throws_If_Source_Is_Empty_And_TSource_Is_Not_Nullable()
         {
-            var foos = new Foo[] { }.ForbidMultipleEnumeration();
+            var items = new DateTime[] { }.ForbidMultipleEnumeration();
             // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
-            Assert.Throws<InvalidOperationException>(() => foos.MaxBy(_getFooValue));
+            Assert.Throws<InvalidOperationException>(() => items.MaxBy(d => d.Ticks));
+        }
+
+        [Fact]
+        public void MaxBy_Returns_Null_If_Source_Is_Empty_And_TSource_Is_Nullable()
+        {
+            var items = new Foo[] { }.ForbidMultipleEnumeration();
+            var actual = items.MaxBy(f => f.Value);
+            actual.Should().BeNull();
         }
 
         [Fact]
@@ -54,11 +62,19 @@ namespace Linq.Extras.Tests.XEnumerableTests
         }
 
         [Fact]
-        public void MinBy_Throws_If_Source_Is_Empty()
+        public void MinBy_Throws_If_Source_Is_Empty_And_TSource_Is_Not_Nullable()
         {
-            var foos = new Foo[] { }.ForbidMultipleEnumeration();
+            var items = new DateTime[] { }.ForbidMultipleEnumeration();
             // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
-            Assert.Throws<InvalidOperationException>(() => foos.MinBy(_getFooValue));
+            Assert.Throws<InvalidOperationException>(() => items.MinBy(d => d.Ticks));
+        }
+
+        [Fact]
+        public void MinBy_Returns_Null_If_Source_Is_Empty_And_TSource_Is_Nullable()
+        {
+            var items = new Foo[] { }.ForbidMultipleEnumeration();
+            var actual = items.MinBy(f => f.Value);
+            actual.Should().BeNull();
         }
 
         [Fact]
@@ -82,6 +98,34 @@ namespace Linq.Extras.Tests.XEnumerableTests
         }
 
         [Fact]
+        public void MinBy_Returns_Item_With_Min_Non_Null_Value_For_Key()
+        {
+            var bars = new[]
+            {
+                new Bar("abcd"),
+                new Bar(null),
+                new Bar("efgh")
+            }.ForbidMultipleEnumeration();
+            var fooWithMinValue = bars.MinBy(b => b.Value);
+            var expected = "abcd";
+            var actual = fooWithMinValue.Value;
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void MinBy_Returns_Item_With_Null_Key_If_All_Items_Have_A_Null_Key()
+        {
+            var bars = new[] {
+                new Bar(null),
+                new Bar(null),
+                new Bar(null)
+            }.ForbidMultipleEnumeration();
+            var fooWithMinValue = bars.MinBy(b => b.Value);
+            var actual = fooWithMinValue.Value;
+            actual.Should().BeNull();
+        }
+
+        [Fact]
         public void Max_Throws_If_Argument_Is_Null()
         {
             var source = Enumerable.Empty<Foo>();
@@ -101,11 +145,19 @@ namespace Linq.Extras.Tests.XEnumerableTests
         }
 
         [Fact]
-        public void Max_Throws_If_Source_Is_Empty()
+        public void Max_Throws_If_Source_Is_Empty_And_TSource_Is_Not_Nullable()
         {
-            var foos = new Foo[] { }.ForbidMultipleEnumeration();
+            var items = new DateTime[] { }.ForbidMultipleEnumeration();
             // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
-            Assert.Throws<InvalidOperationException>(() => foos.Max(new FooComparer()));
+            Assert.Throws<InvalidOperationException>(() => items.Max(Comparer<DateTime>.Default));
+        }
+
+        [Fact]
+        public void Max_Returns_Null_If_Source_Is_Empty_And_TSource_Is_Nullable()
+        {
+            var items = new Foo[] { }.ForbidMultipleEnumeration();
+            var actual = items.Max(new FooComparer());
+            actual.Should().BeNull();
         }
 
         [Fact]
@@ -128,11 +180,19 @@ namespace Linq.Extras.Tests.XEnumerableTests
         }
 
         [Fact]
-        public void Min_Throws_If_Source_Is_Empty()
+        public void Min_Throws_If_Source_Is_Empty_And_TSource_Is_Not_Nullable()
         {
-            var foos = new Foo[] { }.ForbidMultipleEnumeration();
+            var items = new DateTime[] { }.ForbidMultipleEnumeration();
             // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
-            Assert.Throws<InvalidOperationException>(() => foos.Min(new FooComparer()));
+            Assert.Throws<InvalidOperationException>(() => items.Min(Comparer<DateTime>.Default));
+        }
+
+        [Fact]
+        public void Min_Returns_Null_If_Source_Is_Empty_And_TSource_Is_Nullable()
+        {
+            var items = new Foo[] { }.ForbidMultipleEnumeration();
+            var actual = items.Min(new FooComparer());
+            actual.Should().BeNull();
         }
 
         private static IEnumerable<Foo> GetFoos()
@@ -161,6 +221,16 @@ namespace Linq.Extras.Tests.XEnumerableTests
             }
 
             public string Value { get; }
+        }
+
+        private class Bar
+        {
+            public Bar(string? value)
+            {
+                Value = value;
+            }
+
+            public string? Value { get; }
         }
 
         [ExcludeFromCodeCoverage]

--- a/tests/Linq.Extras.Tests/XEnumerableTests/MinMaxTests.cs
+++ b/tests/Linq.Extras.Tests/XEnumerableTests/MinMaxTests.cs
@@ -39,7 +39,7 @@ namespace Linq.Extras.Tests.XEnumerableTests
             var foos = GetFoos().ForbidMultipleEnumeration();
             var fooWithMaxValue = foos.MaxBy(_getFooValue);
             var expected = "xyz";
-            var actual = fooWithMaxValue.Value;
+            var actual = fooWithMaxValue?.Value;
             actual.Should().Be(expected);
         }
 
@@ -49,7 +49,7 @@ namespace Linq.Extras.Tests.XEnumerableTests
             var foos = GetFoos().ForbidMultipleEnumeration();
             var fooWithMaxValue = foos.MaxBy(_getFooValue, Comparer<string>.Default.Reverse());
             var expected = "abcd";
-            var actual = fooWithMaxValue.Value;
+            var actual = fooWithMaxValue?.Value;
             actual.Should().Be(expected);
         }
 
@@ -83,7 +83,7 @@ namespace Linq.Extras.Tests.XEnumerableTests
             var foos = GetFoos().ForbidMultipleEnumeration();
             var fooWithMinValue = foos.MinBy(_getFooValue);
             var expected = "abcd";
-            var actual = fooWithMinValue.Value;
+            var actual = fooWithMinValue?.Value;
             actual.Should().Be(expected);
         }
 
@@ -93,7 +93,7 @@ namespace Linq.Extras.Tests.XEnumerableTests
             var foos = GetFoos().ForbidMultipleEnumeration();
             var fooWithMinValue = foos.MinBy(_getFooValue, Comparer<string>.Default.Reverse());
             var expected = "xyz";
-            var actual = fooWithMinValue.Value;
+            var actual = fooWithMinValue?.Value;
             actual.Should().Be(expected);
         }
 
@@ -108,7 +108,7 @@ namespace Linq.Extras.Tests.XEnumerableTests
             }.ForbidMultipleEnumeration();
             var fooWithMinValue = bars.MinBy(b => b.Value);
             var expected = "abcd";
-            var actual = fooWithMinValue.Value;
+            var actual = fooWithMinValue?.Value;
             actual.Should().Be(expected);
         }
 
@@ -121,7 +121,7 @@ namespace Linq.Extras.Tests.XEnumerableTests
                 new Bar(null)
             }.ForbidMultipleEnumeration();
             var fooWithMinValue = bars.MinBy(b => b.Value);
-            var actual = fooWithMinValue.Value;
+            var actual = fooWithMinValue?.Value;
             actual.Should().BeNull();
         }
 
@@ -140,7 +140,7 @@ namespace Linq.Extras.Tests.XEnumerableTests
             var foos = GetFoos().ForbidMultipleEnumeration();
             var fooWithMaxValue = foos.Max(new FooComparer());
             var expected = "xyz";
-            var actual = fooWithMaxValue.Value;
+            var actual = fooWithMaxValue?.Value;
             actual.Should().Be(expected);
         }
 
@@ -175,7 +175,7 @@ namespace Linq.Extras.Tests.XEnumerableTests
             var foos = GetFoos().ForbidMultipleEnumeration();
             var fooWithMinValue = foos.Min(new FooComparer());
             var expected = "abcd";
-            var actual = fooWithMinValue.Value;
+            var actual = fooWithMinValue?.Value;
             actual.Should().Be(expected);
         }
 


### PR DESCRIPTION
Make them consistent with the native Linq behavior of Min/Max
Add `[return: MaybeNull]` attribute

Fixes #17